### PR TITLE
Reduce HLS segment sizes by adjusting video settings

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -9,12 +9,12 @@ CHANNEL_LIST=/Users/Ted/Development/Broadcaster/channels.json
 # Intel CPU with Intel QuickSync.
 # Using h264_videotoolbox for Mac hardware encoding
 VIDEO_CODEC=h264_videotoolbox
-VIDEO_CRF=28
+VIDEO_CRF=50
 VIDEO_PRESET=veryfast
 VIDEO_FILTER=yadif
 AUDIO_CODEC=aac
 AUDIO_BITRATE=128k
-DIMENSIONS=640x480
+DIMENSIONS=480x360
 FFMPEG_SEEK_AHEAD_SECONDS=30
 
 # Choose the length of HTTP Live Streaming .ts clips. Apple recommends 6 seconds,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,11 +40,11 @@ services:
       # FFmpeg settings (GPU-accelerated)
       - VIDEO_CODEC=h264_nvenc
       - VIDEO_PRESET=p4
-      - VIDEO_CRF=23
+      - VIDEO_CRF=50
       - VIDEO_FILTER=yadif_cuda
       - AUDIO_CODEC=aac
       - AUDIO_BITRATE=128k
-      - DIMENSIONS=640x480
+      - DIMENSIONS=480x360
       - HLS_SEGMENT_LENGTH_SECONDS=1
       - SUPPORTED_FORMATS=mov,mp4,mkv,avi,ts,m2ts,webm,divx,mpg
       - LOG_LEVEL=verbose


### PR DESCRIPTION
- Change resolution from 640x480 to 480x360
- Increase VIDEO_CRF from 23/28 to 50 for higher compression
- Target ~500kB per segment instead of 1.5MB
- Apply settings to both config.txt and docker-compose.yml