### PR TITLE
Replace MD5 hashes with sanitized filenames for video directories

### DIFF
--- a/Classes/PlaylistManager.js
+++ b/Classes/PlaylistManager.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const path = require('path')
-const crypto = require('crypto')
 const Log = require('../Utilities/Log.js')
 const tag = 'PlaylistManager'
 const { CACHE_DIR } = process.env
@@ -13,10 +12,15 @@ class PlaylistManager {
     }
 
     /**
-     * Generate a unique hash for a video file
+     * Generate a safe directory name from a video file path
+     * Uses the filename (without extension) and sanitizes for filesystem safety
      */
     getVideoHash(filePath) {
-        return crypto.createHash('md5').update(filePath).digest('hex')
+        // Get filename without extension
+        const filename = path.basename(filePath, path.extname(filePath))
+        // Replace filesystem-unsafe characters with underscores
+        // Keep alphanumeric, spaces, dashes, parentheses, and dots
+        return filename.replace(/[^a-zA-Z0-9 \-().]/g, '_').trim()
     }
 
     /**

--- a/Utilities/PreGenerator.js
+++ b/Utilities/PreGenerator.js
@@ -2,7 +2,6 @@ const { spawn, execSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
 const Log = require('./Log.js')
-const crypto = require('crypto')
 const tag = 'PreGenerator'
 
 const { CACHE_DIR,
@@ -46,10 +45,15 @@ class PreGenerator {
     }
 
     /**
-     * Generate a unique hash for a video file to use as its HLS directory name
+     * Generate a safe directory name from a video file path
+     * Uses the filename (without extension) and sanitizes for filesystem safety
      */
     getVideoHash(filePath) {
-        return crypto.createHash('md5').update(filePath).digest('hex')
+        // Get filename without extension
+        const filename = path.basename(filePath, path.extname(filePath))
+        // Replace filesystem-unsafe characters with underscores
+        // Keep alphanumeric, spaces, dashes, parentheses, and dots
+        return filename.replace(/[^a-zA-Z0-9 \-().]/g, '_').trim()
     }
 
     /**


### PR DESCRIPTION
Use readable directory names based on the actual video filename instead of MD5 hashes. This makes it much easier to debug and identify which segments belong to which video. Also adds enhanced debug info to the debug endpoint.