### PR TITLE
Revert to MD5 hashes, add manifest endpoint for debugging

### DIFF
--- a/Classes/PlaylistManager.js
+++ b/Classes/PlaylistManager.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const crypto = require('crypto')
 const Log = require('../Utilities/Log.js')
 const tag = 'PlaylistManager'
 const { CACHE_DIR } = process.env
@@ -12,15 +13,11 @@ class PlaylistManager {
     }
 
     /**
-     * Generate a safe directory name from a video file path
-     * Uses the filename (without extension) and sanitizes for filesystem safety
+     * Generate a unique hash for a video file path
+     * The manifest.json maps these hashes back to original filenames
      */
     getVideoHash(filePath) {
-        // Get filename without extension
-        const filename = path.basename(filePath, path.extname(filePath))
-        // Replace filesystem-unsafe characters with underscores
-        // Keep alphanumeric, spaces, dashes, parentheses, and dots
-        return filename.replace(/[^a-zA-Z0-9 \-().]/g, '_').trim()
+        return crypto.createHash('md5').update(filePath).digest('hex')
     }
 
     /**

--- a/Utilities/PreGenerator.js
+++ b/Utilities/PreGenerator.js
@@ -1,6 +1,7 @@
 const { spawn, execSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
+const crypto = require('crypto')
 const Log = require('./Log.js')
 const tag = 'PreGenerator'
 
@@ -45,15 +46,11 @@ class PreGenerator {
     }
 
     /**
-     * Generate a safe directory name from a video file path
-     * Uses the filename (without extension) and sanitizes for filesystem safety
+     * Generate a unique hash for a video file path
+     * The manifest.json maps these hashes back to original filenames
      */
     getVideoHash(filePath) {
-        // Get filename without extension
-        const filename = path.basename(filePath, path.extname(filePath))
-        // Replace filesystem-unsafe characters with underscores
-        // Keep alphanumeric, spaces, dashes, parentheses, and dots
-        return filename.replace(/[^a-zA-Z0-9 \-().]/g, '_').trim()
+        return crypto.createHash('md5').update(filePath).digest('hex')
     }
 
     /**

--- a/Webapp/TelevisionUI.js
+++ b/Webapp/TelevisionUI.js
@@ -216,6 +216,33 @@ class TelevisionUI {
         })
     })
 
+    // Manifest endpoint - shows hash to filename mapping for debugging
+    this.app.get(`/:slug/manifest`, function(req,res){
+        const slug = req.params.slug
+        const manifestPath = path.join(CACHE_DIR, 'channels', slug, 'manifest.json')
+
+        if (!fs.existsSync(manifestPath)) {
+            res.json({ error: 'Manifest not found' })
+            return
+        }
+
+        try {
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+            // Return manifest with hash as key and readable info
+            const result = {}
+            for (const [hash, info] of Object.entries(manifest)) {
+                result[hash] = {
+                    filename: info.filename,
+                    originalPath: info.originalPath,
+                    addedAt: info.addedAt ? new Date(info.addedAt).toISOString() : null
+                }
+            }
+            res.json(result)
+        } catch (e) {
+            res.json({ error: 'Failed to read manifest: ' + e.message })
+        }
+    })
+
     // Dynamic channel routes - matches any *.m3u8 and looks up channel by slug
     this.app.get(`/:slug.m3u8`, function(req,res){
         const slug = req.params.slug


### PR DESCRIPTION
Keep MD5 hashes for safe filesystem directory names, but the manifest.json maps each hash back to the original filename. Added /:slug/manifest endpoint to easily view this mapping for debugging.