### PR TITLE
Only include fully transcoded videos in playlist/guide

### DIFF
--- a/Classes/PlaylistManager.js
+++ b/Classes/PlaylistManager.js
@@ -74,6 +74,12 @@ class PlaylistManager {
 
             try {
                 const content = fs.readFileSync(playlistPath, 'utf8')
+
+                // Only include fully transcoded videos (must have ENDLIST marker)
+                if (!content.includes('#EXT-X-ENDLIST')) {
+                    return
+                }
+
                 const lines = content.split('\n')
 
                 for (let i = 0; i < lines.length; i++) {


### PR DESCRIPTION
Check for #EXT-X-ENDLIST marker before including a video in the master playlist. This prevents partially transcoded videos from appearing in the guide and playlist.